### PR TITLE
Get rid of progress bar in logs

### DIFF
--- a/internal/millers/graph/graphng.go
+++ b/internal/millers/graph/graphng.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
 
 	"gleaner/internal/common"
@@ -41,18 +40,6 @@ func GraphNG(mc *minio.Client, prefix string, v1 *viper.Viper) error {
 	// defer close(doneCh)           // Indicate to our routine to exit cleanly upon return.
 	isRecursive := true
 
-	// Need count for Spiffy progress line  (do I really want this?)
-	// there has got to be a better way to get the count of objects in an object store
-	oc := mc.ListObjects(context.Background(), bucketName, minio.ListObjectsOptions{Prefix: prefix, Recursive: isRecursive})
-	// count := len(objectCh)
-	var count int
-	for x := range oc {
-		count = count + 1
-		log.Println(x)
-	}
-
-	// Old style bar is "ok" since done in sequence?
-	bar := progressbar.Default(int64(count))
 	objectCh := mc.ListObjects(context.Background(), bucketName, minio.ListObjectsOptions{Prefix: prefix, Recursive: isRecursive})
 	// for object := range mc.ListObjects(context.Background(), bucketname, prefix, isRecursive, doneCh) {
 	for object := range objectCh {
@@ -67,10 +54,6 @@ func GraphNG(mc *minio.Client, prefix string, v1 *viper.Viper) error {
 			wg.Done() // tell the wait group that we be done
 			log.Debug("Doc:", object.Key, "error:", err)
 
-			err = bar.Add(1) //bar1.Incr()
-			if err != nil {
-				log.Error(err)
-			}
 			<-semaphoreChan
 		}(object)
 	}

--- a/internal/summoner/acquire/acquire.go
+++ b/internal/summoner/acquire/acquire.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/minio/minio-go/v7"
-	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/viper"
 )
 
@@ -136,9 +135,6 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 		close(semaphoreChan)
 	}()
 
-	count := len(urls)
-	bar := progressbar.Default(int64(count))
-
 	// we actually go get the URLs now
 	for i := range urls {
 		lwg.Add(1)
@@ -230,10 +226,6 @@ func getDomain(v1 *viper.Viper, mc *minio.Client, urls []string, sourceName stri
 
 			UploadWithLogsAndMetadata(v1, mc, cfg.BucketName, sourceName, urlloc, repologger, repoStats, jsonlds)
 
-			err = bar.Add(1) // bar.Incr()
-			if err != nil {
-				log.Error(err) // print an message containing the index (won't keep order)
-			}
 			log.Trace("#", i, "thread for", urlloc)                 // print an message containing the index (won't keep order)
 			time.Sleep(time.Duration(cfg.Delay) * time.Millisecond) // sleep a bit if directed to by the provider
 


### PR DESCRIPTION
Gets rid of the code that was generating the progress bar. This should make things less verbose in the log.

Other logging improvements to follow in future PRs.